### PR TITLE
Added a layer/tag for Github compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: |
             docker build -t jahia/cimg-mvn-cache:ga_$JAHIA_TAG \
             --build-arg FROM_IMAGE="jahia/cimg-mvn-cache:$JAHIA_TAG" \
-            -f Dockerfile-github
+            -f Dockerfile-github .
 
             if [[ "${CIRCLE_BRANCH}" == "<< pipeline.parameters.PRIMARY_RELEASE_BRANCH >>" ]]; then
               docker push jahia/cimg-mvn-cache:ga_$JAHIA_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             echo "FROM_IMAGE=${FROM_IMAGE}"
             echo "JAHIA_TAG=${JAHIA_TAG}"
       - run:
-          name: Build and push Docker image
+          name: Build and push CircleCI Docker image
           command: |
             docker build -t jahia/cimg-mvn-cache:$JAHIA_TAG \
             --build-arg FROM_IMAGE="$FROM_IMAGE" \
@@ -44,6 +44,18 @@ jobs:
 
             if [[ "${CIRCLE_BRANCH}" == "<< pipeline.parameters.PRIMARY_RELEASE_BRANCH >>" ]]; then
               docker push jahia/cimg-mvn-cache:$JAHIA_TAG
+            else
+              echo "Not in the main branch, skipping docker push"
+            fi
+      - run:
+          name: Build and push Github Actions Docker image
+          command: |
+            docker build -t jahia/cimg-mvn-cache:ga_$JAHIA_TAG \
+            --build-arg FROM_IMAGE="jahia/cimg-mvn-cache:$JAHIA_TAG" \
+            -f Dockerfile-github
+
+            if [[ "${CIRCLE_BRANCH}" == "<< pipeline.parameters.PRIMARY_RELEASE_BRANCH >>" ]]; then
+              docker push jahia/cimg-mvn-cache:ga_$JAHIA_TAG
             else
               echo "Not in the main branch, skipping docker push"
             fi

--- a/Dockerfile-github
+++ b/Dockerfile-github
@@ -1,0 +1,9 @@
+ARG FROM_IMAGE=jahia/cimg-mvn-cache:cimg_openjdk_8.0.312-node
+
+FROM $FROM_IMAGE
+
+USER root
+
+RUN mv /home/circleci/.m2 /root/
+
+RUN chown -R root:root /root/.m2


### PR DESCRIPTION
The cached image cannot run "as-is" in Github Actions (https://docs.github.com/en/actions/migrating-to-github-actions/migrating-from-circleci-to-github-actions#using-docker-images).

This creates a child image containing the necessary changes to run in Github Actions.
