### PR TITLE
Added multi-stage build and cleaned-up config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - image: cimg/openjdk:8.0.312-node
     parameters:
       # Milestone used in Testrail
-      from_image:
+      cci_src_image:
         type: string
         default: cimg/openjdk:8.0.312-node
     steps:
@@ -28,18 +28,18 @@ jobs:
       - run:
           name: Creating tag from CircleCI image
           command: |
-            echo "export FROM_IMAGE=<< parameters.from_image >>" >> $BASH_ENV
-            echo "export JAHIA_TAG=$(echo << parameters.from_image >> | sed -r 's/[:\/]+/_/g')" >> $BASH_ENV
+            echo "export CCI_SRC_IMAGE=<< parameters.cci_src_image >>" >> $BASH_ENV
+            echo "export JAHIA_TAG=$(echo << parameters.cci_src_image >> | sed -r 's/[:\/]+/_/g')" >> $BASH_ENV
       - run:
           name: Printing CircleCI image tags
           command: |
-            echo "FROM_IMAGE=${FROM_IMAGE}"
+            echo "CCI_SRC_IMAGE=${CCI_SRC_IMAGE}"
             echo "JAHIA_TAG=${JAHIA_TAG}"
       - run:
           name: Build and push CircleCI Docker image
           command: |
             docker build -t jahia/cimg-mvn-cache:$JAHIA_TAG \
-            --build-arg FROM_IMAGE="$FROM_IMAGE" \
+            --build-arg CCI_SRC_IMAGE="$CCI_SRC_IMAGE" \
             --build-arg GITHUB_API_TOKEN="$GITHUB_API_TOKEN" .
 
             if [[ "${CIRCLE_BRANCH}" == "<< pipeline.parameters.PRIMARY_RELEASE_BRANCH >>" ]]; then
@@ -51,6 +51,7 @@ jobs:
           name: Build and push Github Actions Docker image
           command: |
             docker build -t jahia/cimg-mvn-cache:ga_$JAHIA_TAG \
+            --build-arg CCI_SRC_IMAGE="$CCI_SRC_IMAGE" \
             --build-arg FROM_IMAGE="jahia/cimg-mvn-cache:$JAHIA_TAG" \
             -f Dockerfile-github .
 
@@ -65,7 +66,7 @@ workflows:
     jobs:
       - build_publish:
           context: QA_ENVIRONMENT
-          from_image: 'cimg/openjdk:8.0.312-node'
+          cci_src_image: 'cimg/openjdk:8.0.312-node'
 
   # The objective of nightly runs is to ensure keep up to date the artifacts
   # for the projects listed in the Dockerfile
@@ -80,5 +81,5 @@ workflows:
     jobs:
       - build_publish:
           context: QA_ENVIRONMENT
-          from_image: 'cimg/openjdk:8.0.312-node'
+          cci_src_image: 'cimg/openjdk:8.0.312-node'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG FROM_IMAGE=cimg/openjdk:8.0.312-node
+ARG CCI_SRC_IMAGE=cimg/openjdk:8.0.312-node
 
-FROM $FROM_IMAGE
+FROM $CCI_SRC_IMAGE
 ARG GITHUB_API_TOKEN
 
 RUN git clone https://$GITHUB_API_TOKEN@github.com/Jahia/jahia-private.git; \

--- a/Dockerfile-github
+++ b/Dockerfile-github
@@ -1,9 +1,16 @@
 ARG FROM_IMAGE=jahia/cimg-mvn-cache:cimg_openjdk_8.0.312-node
+ARG CCI_SRC_IMAGE=cimg/openjdk:8.0.312-node
 
-FROM $FROM_IMAGE
+FROM $FROM_IMAGE as warmed-up-image
 
 USER root
 
-RUN mv /home/circleci/.m2 /root/
+RUN mv /home/circleci/.m2 /root/; \
+    chown -R root:root /root/.m2
 
-RUN chown -R root:root /root/.m2
+# Using a multi-stage build to reduce the overall image size
+FROM $CCI_SRC_IMAGE
+
+USER root
+
+COPY --from=warmed-up-image /root/ /root/


### PR DESCRIPTION
Layers on the child image for github actions were taking a lot of space.

This lowers the size of the image.
