### PR TITLE
chore: updated to the latest jahia release tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,21 +11,15 @@ RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 RUN --mount=type=ssh git clone git@github.com:Jahia/jahia-private.git; \
     cd jahia-private;\
     mvn -B -s ../maven.settings.xml dependency:resolve;\
-    git checkout -b JAHIA_8_2_0_6 JAHIA_8_2_0_6;\
+    git checkout -b JAHIA_8_2_1_0 JAHIA_8_2_1_0;\
+    mvn -B -s ../maven.settings.xml dependency:resolve    
+    git checkout -b JAHIA_8_2_0_7 JAHIA_8_2_0_7;\
     mvn -B -s ../maven.settings.xml dependency:resolve;\
-    git checkout -b JAHIA_8_1_6_0 JAHIA_8_1_6_0;\
+    git checkout -b JAHIA_8_1_8_2 JAHIA_8_1_8_2;\
     mvn -B -s ../maven.settings.xml dependency:resolve;\
-    git checkout -b JAHIA_8_1_5_1 JAHIA_8_1_5_1;\
+    git checkout -b JAHIA_8_1_7_2 JAHIA_8_1_7_2;\
     mvn -B -s ../maven.settings.xml dependency:resolve;\
-    git checkout -b JAHIA_8_1_3_1 JAHIA_8_1_3_1;\
-    mvn -B -s ../maven.settings.xml dependency:resolve;\
-    git checkout -b JAHIA_8_1_2_3 JAHIA_8_1_2_3;\
-    mvn -B -s ../maven.settings.xml dependency:resolve;\
-    git checkout -b JAHIA_8_1_0_0 JAHIA_8_1_0_0;\
-    mvn -B -s ../maven.settings.xml dependency:resolve;\
-    git checkout -b JAHIA_8_0_3_0 JAHIA_8_0_3_0;\
-    mvn -B -s ../maven.settings.xml dependency:resolve;\
-    git checkout -b JAHIA_7_3_10_0 JAHIA_7_3_10_0;\
+    git checkout -b JAHIA_8_1_6_2 JAHIA_8_1_6_2;\
     mvn -B -s ../maven.settings.xml dependency:resolve;\
     cd ..; rm -Rf jahia-private
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=ssh git clone git@github.com:Jahia/jahia-private.git; \
     cd jahia-private;\
     mvn -B -s ../maven.settings.xml dependency:resolve;\
     git checkout -b JAHIA_8_2_1_0 JAHIA_8_2_1_0;\
-    mvn -B -s ../maven.settings.xml dependency:resolve    
+    mvn -B -s ../maven.settings.xml dependency:resolve
     git checkout -b JAHIA_8_2_0_7 JAHIA_8_2_0_7;\
     mvn -B -s ../maven.settings.xml dependency:resolve;\
     git checkout -b JAHIA_8_1_8_2 JAHIA_8_1_8_2;\


### PR DESCRIPTION
I'm quite sure we do not need to keep such old versions in our image cache.